### PR TITLE
fix: remove nonexistent ovos-utils extra from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ovos-utils[extra]
+ovos-utils>=0.0.38,<1.0.0
 langcodes

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from packaging.requirements import Requirement
+
+BASEDIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+REQUIREMENTS = os.path.join(BASEDIR, "requirements.txt")
+
+# extras actually provided by dependencies used in requirements.txt
+KNOWN_EXTRAS = {
+    "ovos-utils": set(),
+    "langcodes": {"data"},
+}
+
+
+class TestRequirements(unittest.TestCase):
+    def _requirements(self):
+        with open(REQUIREMENTS) as f:
+            lines = [l.strip() for l in f.read().splitlines()]
+        return [Requirement(l) for l in lines
+                if l and not l.startswith("#")]
+
+    def test_no_nonexistent_extras(self):
+        for req in self._requirements():
+            allowed = KNOWN_EXTRAS.get(req.name, set())
+            self.assertTrue(
+                set(req.extras) <= allowed,
+                f"{req.name} declares unknown extra(s): {req.extras}")
+
+    def test_ovos_utils_plain_with_floor(self):
+        reqs = {r.name: r for r in self._requirements()}
+        self.assertIn("ovos-utils", reqs)
+        req = reqs["ovos-utils"]
+        self.assertEqual(set(req.extras), set())
+        self.assertTrue(len(req.specifier) > 0,
+                        "ovos-utils must declare a version constraint")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`requirements.txt` declares `ovos-utils[extra]`, but ovos-utils provides no `extra` extra. Every install of the released package emits an installer warning about the unknown extra.

## Fix
- Depend on plain `ovos-utils>=0.0.38,<1.0.0`.
- Add `test/test_requirements.py`, which parses `requirements.txt` and fails if any dependency names an extra the package does not provide, and asserts `ovos-utils` is required without extras and with a version constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `ovos-utils` dependency specification to use a supported version range without extras.
  * Retained `langcodes` as a project dependency.

* **Tests**
  * Added validation to detect unsupported dependency extras.
  * Added coverage confirming `ovos-utils` uses a version constraint and no extras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->