### PR TITLE
docs: cross-domain README, reference docs, and runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,173 @@
+# ovos-lang-parser
 
-## Related Projects
+Map spoken and written **language names** to standard **IETF/BCP-47 language codes** — and
+back — in many languages, offline, with a two-function API.
 
-- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) - for handling numbers
-- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser) - for handling dates and times
-- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) - for handling colors
+```
+"Brazilian Portuguese"  ->  "pt-br"
+"alemão" (Portuguese)   ->  "de"
+"pt-br"  ->  "Português do Brasil"   (rendered in Portuguese)
+"pt-br"  ->  "Brazilian Portuguese"  (rendered in English)
+```
+
+The library understands language names written in **21 languages** (see
+[Coverage](#coverage)). A user can say "French" in English, "français" in French, or
+"Französisch" in German, and each resolves to the code `fr`. This is the piece you need
+whenever a human names a language in free text and your code needs a canonical code to act
+on — routing to a translation/TTS/STT engine, tagging an entity, or normalizing a messy
+label.
+
+It ships as part of OpenVoiceOS, but has **no OVOS runtime dependency** and is useful in any
+plain-Python project.
+
+## Install
+
+```bash
+pip install ovos-lang-parser
+# or
+uv add ovos-lang-parser
+```
+
+Runtime dependencies are small: [`langcodes`](https://github.com/rspeer/langcodes) for tag
+normalization and `ovos-utils` for the fuzzy matcher. No models, no network calls — the
+wordlists are bundled.
+
+## 30-second quickstart
+
+```python
+from ovos_lang_parser import extract_langcode, pronounce_lang
+
+# name -> code (second arg is the language the text is written in)
+print(extract_langcode("Brazilian Portuguese", "en"))          # -> ('pt-br', 1.0)
+print(extract_langcode("translate this to German", "en"))      # -> ('de', 1.0)
+
+# code -> name, rendered in a chosen language
+print(pronounce_lang("de", "en"))   # -> German
+print(pronounce_lang("de", "pt"))   # -> Alemão
+```
+
+That is the whole surface for most callers: `extract_langcode` reads a name out of text and
+returns `(code, confidence)`; `pronounce_lang` turns a code back into a human name.
+
+## The API in one screen
+
+| Function | Purpose | Returns |
+|----------|---------|---------|
+| `extract_langcode(text, lang)` | Find the language named in `text` (written in `lang`) | `(langcode, confidence)` — confidence `0.0`–`1.0`; an exact name match is `1.0` |
+| `pronounce_lang(langcode, lang)` | Human name of `langcode`, rendered in `lang` | `str` (falls back to the base tag, then to `langcode` unchanged) |
+| `get_lang_data(lang)` | The full `{name: code}` table for `lang` | `dict[str, str]` |
+| `LANGS` | Codes of the languages a name can be written in | `list[str]` |
+
+In both functions `lang` is the language the *names* are written in, not the language being
+named. `extract_langcode("français", "fr")` and `extract_langcode("French", "en")` both give
+`fr`. See [docs/api.md](docs/api.md) for full signatures, the confidence model, and edge
+behavior.
+
+## Use it outside OVOS
+
+The same two functions cover a range of standalone jobs. Each example below is a runnable
+script under [`examples/`](examples/) — `pip install ovos-lang-parser` and run it, no OVOS
+stack required.
+
+### Entity extraction / NER — pull a language out of free text
+
+You have a sentence and want to know which language it mentions.
+
+```python
+from ovos_lang_parser import extract_langcode
+
+for text in ["translate this to Brazilian Portuguese",
+             "can you say it in Mandarin Chinese?",
+             "I'd like the subtitles in Greek"]:
+    code, conf = extract_langcode(text, "en")
+    if conf >= 0.7:
+        print(f"{text!r} -> {code} ({conf:.2f})")
+```
+
+Because matching is fuzzy, apply a confidence threshold to decide whether a language was
+really mentioned. Full script:
+[`examples/ner_language_mentions.py`](examples/ner_language_mentions.py).
+
+### Routing — pick a translation / TTS / STT engine by name
+
+A user names a target language; you resolve it to a code and hand that to whatever engine
+your pipeline drives.
+
+```python
+from ovos_lang_parser import extract_langcode
+
+def resolve_target(user_request, spoken_in="en"):
+    code, conf = extract_langcode(user_request, spoken_in)
+    return code if conf >= 0.7 else None
+
+print(resolve_target("read it back to me in German"))   # -> de  (feed to your TTS)
+```
+
+Full script (with a mock engine table): [`examples/routing.py`](examples/routing.py).
+
+### Normalization — canonicalize messy names and autonyms to one code
+
+Aliases, autonyms, and localized spellings all collapse to a single canonical code, so you
+can deduplicate and standardize labels regardless of how they were written.
+
+```python
+from ovos_lang_parser import extract_langcode
+
+labels = [("Deutsch", "de"), ("alemão", "pt"), ("German", "en"), ("allemand", "fr")]
+for name, written_in in labels:
+    code, _ = extract_langcode(name, written_in)
+    print(f"{name:>10} -> {code}")   # all -> de
+```
+
+Full script: [`examples/normalization.py`](examples/normalization.py).
+
+### In an OVOS skill vs. standalone
+
+The API is identical; only where you get `text` and `lang` differs.
+
+```python
+# Standalone language-routing utility
+code, conf = extract_langcode(user_input, "en")
+
+# Inside an OVOS skill — the utterance and its language come from the session
+class MySkill(OVOSSkill):
+    def handle_translate(self, message):
+        utterance = message.data["utterance"]
+        code, conf = extract_langcode(utterance, self.lang)
+        ...
+```
+
+## Coverage
+
+Names can be written in **21 languages**; each carries a table of a few hundred target
+languages keyed by ISO 639 code.
+
+| | | | |
+|---|---|---|---|
+| `an` Aragonese | `ar` Arabic | `ast` Asturian | `bg` Bulgarian |
+| `ca` Catalan | `da` Danish | `de` German | `en` English |
+| `es` Spanish | `eu` Basque | `fr` French | `fy` Frisian |
+| `gl` Galician | `hr` Croatian | `it` Italian | `kab` Kabyle |
+| `nl` Dutch | `oc` Occitan | `pt` Portuguese | `ro` Romanian |
+| `sk` Slovak | | | |
+
+The live list is always `ovos_lang_parser.LANGS`. Adding a language is a matter of dropping
+in one JSON file — see [docs/coverage.md](docs/coverage.md) and
+[docs/extending.md](docs/extending.md).
+
+## Documentation
+
+- [docs/api.md](docs/api.md) — full reference, confidence model, edge behavior
+- [docs/coverage.md](docs/coverage.md) — supported languages and the data model
+- [docs/extending.md](docs/extending.md) — add a language wordlist
+- [examples/](examples/) — runnable scripts for each use case
+
+## Related projects
+
+- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) — numbers
+- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser) — dates and times
+- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) — colors
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,156 @@
+# API reference
+
+Everything is importable from the top-level package:
+
+```python
+from ovos_lang_parser import (
+    extract_langcode,
+    pronounce_lang,
+    get_lang_data,
+    LANGS,
+)
+```
+
+Two ideas run through the whole API:
+
+- A **language code** is an IETF/BCP-47 tag such as `en`, `pt`, or `pt-br`. Codes are
+  normalized to their modern lowercase form, so legacy tags collapse to the current one
+  (`iw` → `he`, `jw` → `jv`, `mo` → `ro`).
+- The **`lang`** argument is always *the language the names are written in* — not the
+  language being named. To read a French sentence, pass `lang="fr"`; the code it resolves to
+  can be any language.
+
+---
+
+## `extract_langcode(text, lang) -> tuple[str, float]`
+
+Find the language named in `text`, where `text` is written in `lang`.
+
+| Parameter | Type | Meaning |
+|-----------|------|---------|
+| `text` | `str` | Free text that mentions a language, e.g. `"translate to German"`. |
+| `lang` | `str` | The language `text` is written in (must resolve to one of `LANGS`). |
+
+Returns `(langcode, confidence)`:
+
+- `langcode` — the best-matching BCP-47 code.
+- `confidence` — a float in `0.0`–`1.0`.
+
+Matching works in two stages:
+
+1. **Exact match.** If `text`, whitespace-collapsed and case-folded, equals a known name, the
+   result is that code with confidence `1.0`.
+2. **Fuzzy match.** Otherwise a token-set-ratio matcher scores `text` against every known
+   name and returns the best one. Because it is token-set based, a clean language name
+   surrounded by other words still scores `1.0` — the surrounding tokens do not count against
+   it. What *does* lower the score is punctuation stuck to the name (`Chinese?`), a
+   misspelling, or text with no language name at all.
+
+```python
+extract_langcode("Portuguese", "en")                  # ('pt', 1.0)   exact
+extract_langcode("translate this to German", "en")    # ('de', 1.0)   name is a clean token
+extract_langcode("alemão", "pt")                       # ('de', 1.0)   exact, in Portuguese
+extract_langcode("inglés", "es")                       # ('en', 1.0)   exact, in Spanish
+extract_langcode("say it in Mandarin Chinese?", "en")  # ('zh', 0.41)  '?' stuck to the name
+```
+
+For best results on free text, strip surrounding punctuation before calling.
+
+### Confidence and thresholds
+
+Because stage 2 always returns *some* best match, `extract_langcode` never signals "no
+language here" on its own — text with no language mention still returns a low-confidence
+guess:
+
+```python
+extract_langcode("the weather today", "en")           # e.g. ('rm', 0.45)  — noise
+```
+
+Apply a threshold suited to your input. As a rule of thumb:
+
+- **`== 1.0`** — a clean, unambiguous name (safe to trust).
+- **`>= 0.7`** — a confident mention (good default for NER/routing).
+- **`< 0.5`** — treat as "no language mentioned".
+
+Tune against your own data; noisy free text warrants a higher floor than short labels, and
+stripping punctuation first keeps genuine mentions above the threshold.
+
+### Errors
+
+Raises `ValueError` if `lang` has no bundled wordlist and is too far from any that does.
+
+---
+
+## `pronounce_lang(langcode, lang) -> str`
+
+The human-readable name of `langcode`, rendered in the language `lang`.
+
+| Parameter | Type | Meaning |
+|-----------|------|---------|
+| `langcode` | `str` | The BCP-47 code to name, e.g. `"de"` or `"pt-br"`. |
+| `lang` | `str` | The language the returned name should be written in. |
+
+```python
+pronounce_lang("de", "en")       # 'German'
+pronounce_lang("de", "pt")       # 'Alemão'
+pronounce_lang("pt-br", "en")    # 'Brazilian Portuguese'
+pronounce_lang("pt-br", "pt")    # 'Português do Brasil'
+```
+
+Resolution order:
+
+1. The name for the full tag (`pt-br`), if the wordlist has one.
+2. Otherwise the name for the base subtag (`pt`).
+3. Otherwise `langcode` returned unchanged (never raises for an unknown code):
+
+```python
+pronounce_lang("xx-YY", "en")    # 'xx-YY'
+```
+
+When a language has several spellings, the **first** listed in the wordlist is treated as
+canonical and is what `pronounce_lang` returns.
+
+---
+
+## `get_lang_data(lang) -> dict[str, str]`
+
+The full `{name: code}` lookup table for names written in `lang`. Every known spelling of a
+language appears as a key, all mapping to the same code.
+
+```python
+data = get_lang_data("en")
+data["German"]      # 'de'
+data["Portuguese"]  # 'pt'
+len(data)           # hundreds of entries
+```
+
+Use this when you want to do your own matching, build an autocomplete list, or inspect what
+the library knows. Raises `ValueError` if `lang` has no bundled wordlist.
+
+---
+
+## `LANGS -> list[str]`
+
+Sorted list of the language codes whose names the library can parse — i.e. valid values for
+the `lang` argument.
+
+```python
+import ovos_lang_parser
+ovos_lang_parser.LANGS
+# ['an', 'ar', 'ast', 'bg', 'ca', 'da', 'de', 'en', 'es', 'eu', 'fr',
+#  'fy', 'gl', 'hr', 'it', 'kab', 'nl', 'oc', 'pt', 'ro', 'sk']
+```
+
+`lang` does not have to be an exact member — it is matched to the closest available wordlist,
+so `en-us` and `en-gb` both use the `en` list. Only a `lang` with no close match raises.
+
+---
+
+## Notes for advanced use
+
+- **Caching.** Wordlists are loaded once and memoized (`lru_cache`), so repeated calls are
+  cheap. The first call for a given `lang` pays the JSON-load cost.
+- **Thread safety.** All functions are pure reads over immutable in-memory data; safe to call
+  concurrently.
+- **No network, no models.** Everything resolves from bundled JSON under the package's `res/`
+  directory. See [coverage.md](coverage.md) for the data model.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,82 @@
+# Coverage and data model
+
+## Languages you can parse names in
+
+`extract_langcode`, `pronounce_lang`, and `get_lang_data` all take a `lang` argument —
+the language the *names* are written in. The library ships wordlists for **21** of them:
+
+| Code | Language | Code | Language | Code | Language |
+|------|----------|------|----------|------|----------|
+| `an` | Aragonese | `de` | German | `it` | Italian |
+| `ar` | Arabic | `en` | English | `kab` | Kabyle |
+| `ast` | Asturian | `es` | Spanish | `nl` | Dutch |
+| `bg` | Bulgarian | `eu` | Basque | `oc` | Occitan |
+| `ca` | Catalan | `fr` | French | `pt` | Portuguese |
+| `da` | Danish | `fy` | Frisian | `ro` | Romanian |
+| | | `gl` | Galician | `sk` | Slovak |
+| | | `hr` | Croatian | | |
+
+The authoritative, runtime list is always:
+
+```python
+import ovos_lang_parser
+ovos_lang_parser.LANGS
+```
+
+A `lang` value does not have to be an exact member — it is matched to the closest wordlist,
+so regional variants like `en-us` or `pt-pt` resolve to `en` / `pt`. A `lang` too far from
+any bundled list raises `ValueError`.
+
+## What each wordlist covers
+
+Each wordlist maps a few hundred **target** languages (keyed by ISO 639 code) to their names
+in that language. So the `en` wordlist knows the English names of hundreds of languages, the
+`pt` wordlist their Portuguese names, and so on. The target set is far broader than the 21
+name languages above — you can resolve "Swahili", "Tibetan", or "Esperanto" even though the
+library cannot parse names *written in* those languages.
+
+Approximate distinct target codes per wordlist:
+
+| `lang` | targets | `lang` | targets | `lang` | targets |
+|--------|--------:|--------|--------:|--------|--------:|
+| `an` | 242 | `es` | 153 | `nl` | 153 |
+| `ar` | 134 | `eu` | 140 | `oc` | 156 |
+| `ast` | 182 | `fr` | 153 | `pt` | 186 |
+| `bg` | 148 | `fy` | 169 | `ro` | 153 |
+| `ca` | 153 | `gl` | 153 | `sk` | 148 |
+| `da` | 153 | `hr` | 148 | | |
+| `de` | 184 | `it` | 153 | | |
+| `en` | 153 | `kab` | 134 | | |
+
+## The data model
+
+Wordlists live under `ovos_lang_parser/res/<lang>/langs.json`. Each file is a JSON object
+keyed by BCP-47 code:
+
+```json
+{
+  "de": "German",
+  "pt": "Portuguese",
+  "pt-br": "Brazilian Portuguese",
+  "en-us": "American English"
+}
+```
+
+A value may also be a **template** using `(a|b)` alternation, which the loader expands into
+every spelling. For example `"Bislamá Bichlamar"` and templated forms like
+`"(Modern |)Greek"` become multiple accepted names, all mapping to the same code. The
+**first** name listed for a code is treated as canonical — it is what `pronounce_lang`
+returns.
+
+At load time (`get_lang_data` / the internal loader):
+
+- codes are normalized to modern lowercase form (legacy `iw` → `he`, `jw` → `jv`,
+  `mo` → `ro`), so duplicate aliases merge onto one code;
+- templates are expanded to individual names;
+- results are memoized so a wordlist is parsed only once.
+
+Both full and base tags coexist: `pt` and `pt-br` are separate keys, which is what lets
+`extract_langcode` return `pt-br` for "Brazilian Portuguese" while `pronounce_lang("pt-br",
+…)` falls back to the `pt` name when a region-specific one is absent.
+
+To add a language, see [extending.md](extending.md).

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,73 @@
+# Adding a language
+
+Teaching the parser to read language names written in a new language means adding one
+wordlist. No code changes are required — `LANGS` is discovered from the filesystem at import
+time.
+
+## Steps
+
+1. **Create the directory and file:**
+
+   ```
+   ovos_lang_parser/res/<lang>/langs.json
+   ```
+
+   where `<lang>` is the BCP-47 code of the language the names are written in (for example
+   `sv` for Swedish).
+
+2. **Fill in `{code: name}` pairs.** Key each entry by the BCP-47 code of the *target*
+   language; the value is that language's name in `<lang>`:
+
+   ```json
+   {
+     "en": "engelska",
+     "de": "tyska",
+     "pt": "portugisiska",
+     "pt-br": "brasiliansk portugisiska"
+   }
+   ```
+
+   - The **first** name for a code is canonical — it is what `pronounce_lang` returns. List
+     the most natural spelling first.
+   - Provide both base and regional tags where they differ (`pt` and `pt-br`); a regional tag
+     with no entry falls back to the base name automatically.
+
+3. **Add spelling variants with templates** when several forms should all resolve to one
+   code. Use `(a|b)` alternation in a single string value:
+
+   ```json
+   { "el": "(nygrekiska|grekiska)" }
+   ```
+
+   Both "nygrekiska" and "grekiska" become accepted names for `el`. Alternations can appear
+   anywhere in the string and nest.
+
+That is the whole contribution — drop the file in, and the new code appears in `LANGS`
+automatically.
+
+## Verifying your wordlist
+
+```python
+import ovos_lang_parser
+from ovos_lang_parser import extract_langcode, pronounce_lang, get_lang_data
+
+assert "<lang>" in ovos_lang_parser.LANGS
+
+# names resolve back to codes
+assert extract_langcode("<a name from your file>", "<lang>")[0] == "<expected code>"
+
+# codes resolve back to your canonical names
+print(pronounce_lang("de", "<lang>"))
+
+# inspect the whole table
+print(len(get_lang_data("<lang>")), "names loaded")
+```
+
+## Conventions
+
+- Codes are normalized to modern lowercase form on load, so you may use legacy aliases
+  (`iw`, `jw`, `mo`) — they merge onto the current code (`he`, `jv`, `ro`). Prefer the modern
+  code when authoring.
+- Keep the file UTF-8 and valid JSON; the loader reads it directly.
+- Names are matched case-insensitively at runtime, so casing in the file is only cosmetic —
+  but keep it natural for `pronounce_lang` output.

--- a/examples/_bootstrap.py
+++ b/examples/_bootstrap.py
@@ -1,0 +1,21 @@
+"""Shared setup for the example scripts.
+
+Importing this module does two convenience things so the examples run cleanly
+from a checkout:
+
+* Puts the repository root on ``sys.path`` so ``import ovos_lang_parser`` uses
+  the code in this checkout, even if an older release is also installed.
+* Quiets the OVOS logger so example output is not buried in deprecation notices.
+
+None of this is needed in your own project — there you just
+``pip install ovos-lang-parser`` and ``import ovos_lang_parser``.
+"""
+import logging
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+logging.getLogger("OVOS").setLevel(logging.ERROR)

--- a/examples/ner_language_mentions.py
+++ b/examples/ner_language_mentions.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Entity extraction / NER: pull the language mentioned in free text.
+
+Standalone, no OVOS stack required:
+
+    pip install ovos-lang-parser
+    python examples/ner_language_mentions.py
+
+`extract_langcode` always returns a best-guess match, so we apply a confidence
+threshold to decide whether a language was really mentioned.
+"""
+import _bootstrap  # noqa: F401  (repo-local path + quiet logging; see _bootstrap.py)
+
+from ovos_lang_parser import extract_langcode, pronounce_lang
+
+THRESHOLD = 0.7
+
+# Free text in English that may or may not name a language.
+SAMPLES = [
+    "translate this to Brazilian Portuguese",
+    "can you say it in Mandarin Chinese",
+    "I'd like the subtitles in Greek",
+    "I need this dubbed into Korean",
+    "put the captions in Japanese",
+    "the weather looks nice today",   # no language mentioned
+]
+
+
+def detect_language_mention(text, written_in="en"):
+    code, conf = extract_langcode(text, written_in)
+    if conf < THRESHOLD:
+        return None
+    return code, conf
+
+
+def main():
+    for text in SAMPLES:
+        hit = detect_language_mention(text, "en")
+        if hit is None:
+            print(f"[  -- ] {text!r}\n        no language mentioned")
+        else:
+            code, conf = hit
+            english_name = pronounce_lang(code, "en")
+            print(f"[{code:>5}] {text!r}\n        -> {english_name} (confidence {conf:.2f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/normalization.py
+++ b/examples/normalization.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Normalization: canonicalize messy language names to one standard code.
+
+Standalone, no OVOS stack required:
+
+    pip install ovos-lang-parser
+    python examples/normalization.py
+
+Aliases, autonyms, and localized spellings all collapse onto a single BCP-47
+code, so labels can be deduplicated and standardized regardless of how they were
+written. `pronounce_lang` then gives a single canonical display name.
+"""
+import _bootstrap  # noqa: F401  (repo-local path + quiet logging; see _bootstrap.py)
+
+from collections import defaultdict
+
+from ovos_lang_parser import extract_langcode, pronounce_lang
+
+# Messy labels as (name, language the name is written in) from mixed sources.
+# Every "German" spelling below should collapse onto the single code "de".
+RAW_LABELS = [
+    ("Deutsch", "de"),      # German autonym
+    ("alemão", "pt"),       # German, in Portuguese
+    ("German", "en"),       # German, in English
+    ("allemand", "fr"),     # German, in French
+    ("tedesco", "it"),      # German, in Italian
+    ("English", "en"),
+    ("inglés", "es"),       # English, in Spanish
+    ("Français", "fr"),     # French autonym
+    ("francês", "pt"),      # French, in Portuguese
+]
+
+
+def canonicalize(name, written_in):
+    code, conf = extract_langcode(name, written_in)
+    return code if conf >= 0.9 else None  # normalization wants near-exact matches
+
+
+def main():
+    buckets = defaultdict(list)
+    for name, written_in in RAW_LABELS:
+        code = canonicalize(name, written_in)
+        buckets[code].append(name)
+
+    print("Canonicalized groups (all spellings -> one code -> one display name):\n")
+    for code in sorted(k for k in buckets if k is not None):
+        display = pronounce_lang(code, "en")
+        joined = ", ".join(buckets[code])
+        print(f"  {code:>3}  {display:<8}  <-  {joined}")
+    if None in buckets:
+        print(f"\n  [unresolved] {buckets[None]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/routing.py
+++ b/examples/routing.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Routing: resolve a user-named target language to a code, then pick an engine.
+
+Standalone, no OVOS stack required:
+
+    pip install ovos-lang-parser
+    python examples/routing.py
+
+A multilingual pipeline (translation / TTS / STT) needs a canonical code before
+it can choose a backend. `extract_langcode` turns what the user said into that
+code; here a mock engine registry stands in for the real backends.
+"""
+import _bootstrap  # noqa: F401  (repo-local path + quiet logging; see _bootstrap.py)
+
+from ovos_lang_parser import extract_langcode, pronounce_lang
+
+THRESHOLD = 0.7
+
+# Pretend these are the languages your TTS/translation backends support.
+ENGINE_REGISTRY = {
+    "de": "tts.german.v2",
+    "fr": "tts.french.v2",
+    "pt": "tts.portuguese.v1",
+    "pt-br": "tts.portuguese-br.v1",
+    "en": "tts.english.v3",
+    "es": "tts.spanish.v2",
+    "it": "tts.italian.v1",
+}
+
+
+def route(user_request, spoken_in="en"):
+    code, conf = extract_langcode(user_request, spoken_in)
+    if conf < THRESHOLD:
+        return None, "could not identify a target language"
+
+    # exact engine, else fall back to the base language
+    engine = ENGINE_REGISTRY.get(code) or ENGINE_REGISTRY.get(code.split("-")[0])
+    if engine is None:
+        name = pronounce_lang(code, "en")
+        return code, f"{name} ({code}) recognized but no engine available"
+    return code, engine
+
+
+# (request, language the request is written in)
+REQUESTS = [
+    ("read it back to me in German", "en"),
+    ("switch the voice to Brazilian Portuguese", "en"),
+    ("I want French please", "en"),
+    ("italiano", "it"),                     # user names the target in Italian
+    ("say something in Swahili", "en"),     # recognized but unsupported target
+    ("play some music", "en"),              # no language at all
+]
+
+
+def main():
+    for request, spoken_in in REQUESTS:
+        code, result = route(request, spoken_in)
+        tag = code if code else "??"
+        print(f"{request!r:46} -> [{tag}] {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Polishes the documentation so it serves both newcomers and advanced developers, and shows how the library is useful outside OVOS.

## README
- Value proposition up front: map language names <-> IETF/BCP-47 codes, in both directions, offline.
- Install (pip and uv), a 30-second quickstart, and an API-in-one-screen table.
- **Standalone (non-OVOS) use cases** with copy-pasteable snippets: NER / language-mention extraction, translation/TTS/STT routing, and name normalization, plus an "in an OVOS skill vs. standalone" contrast.
- Coverage summary (21 name languages) and links into docs/.

## docs/
- `api.md` — full reference for `extract_langcode`, `pronounce_lang`, `get_lang_data`, `LANGS`, the confidence model, and edge behavior.
- `coverage.md` — supported languages and the wordlist data model.
- `extending.md` — how to add a language wordlist.

## examples/
Runnable scripts, one per use case: `ner_language_mentions.py`, `routing.py`, `normalization.py` (with a shared `_bootstrap.py` helper). Each was executed and produces the documented output.

Documentation only — no library code changed. Everything documented reflects the actual public API.