### PR TITLE
fix: tolerate non-string and embedded language names in extraction

### DIFF
--- a/ovos_lang_parser/__init__.py
+++ b/ovos_lang_parser/__init__.py
@@ -94,14 +94,35 @@ def extract_langcode(text: str, lang: str) -> Tuple[str, float]:
 
     ``lang`` is the language the utterance is spoken in. Returns a
     ``(langcode, confidence)`` tuple; confidence is between 0 and 1.
+    A non-string or blank ``text`` yields ``("", 0.0)`` rather than raising.
     """
     langs = get_lang_data(lang)
-    # an exact name match always wins over fuzzy matching
-    query = " ".join(text.split()).casefold()
+    if not isinstance(text, str) or not text.strip():
+        return "", 0.0
+    tokens = text.casefold().split()
+    query = " ".join(tokens)
+    # An exact name match always wins over fuzzy matching. A name that
+    # appears verbatim as a run of whole words in a longer utterance
+    # ("quiero aprender japonés") counts as exact too; the most specific
+    # (longest) such name wins, so "American English" beats "English".
+    best = None  # (span, -start, code)
     for name, code in langs.items():
-        if name.casefold() == query:
-            return code, 1.0
-    return match_one(text, langs, strategy=MatchStrategy.TOKEN_SET_RATIO)
+        name_tokens = name.casefold().split()
+        span = len(name_tokens)
+        for i in range(len(tokens) - span + 1) if span else ():
+            if tokens[i:i + span] == name_tokens:
+                key = (span, -i, code)
+                if best is None or key[:2] > best[:2]:
+                    best = key
+                break
+    if best is not None:
+        return best[2], 1.0
+    code, conf = match_one(query, langs, strategy=MatchStrategy.TOKEN_SET_RATIO)
+    # a zero-confidence "match" is no match at all; don't return an
+    # arbitrary code for it
+    if not conf:
+        return "", 0.0
+    return code, conf
 
 
 def pronounce_lang(lang_code: str, lang: str) -> str:
@@ -109,8 +130,10 @@ def pronounce_lang(lang_code: str, lang: str) -> str:
 
     Falls back to the primary subtag (e.g. ``pt-br`` -> ``pt``) when the
     full tag has no dedicated name, and returns ``lang_code`` unchanged
-    if the wordlist has no name for it at all.
+    if the wordlist has no name for it at all (or is not a string).
     """
+    if not isinstance(lang_code, str):
+        return lang_code
     names = {code: spoken[0]
              for code, spoken in _load_wordlist(_closest_lang(lang))
              if spoken}

--- a/test/test_lang_parser.py
+++ b/test/test_lang_parser.py
@@ -203,6 +203,60 @@ class TestExtractLangcode(unittest.TestCase):
         with self.assertRaises(ValueError):
             extract_langcode("English", "zz")
 
+    def test_name_in_natural_sentence(self):
+        # a language name embedded in a full utterance is recovered exactly
+        cases = [
+            ("translate this into Brazilian Portuguese", "en", "pt-br"),
+            ("say it in Chinese", "en", "zh"),
+            ("can you speak German with me", "en", "de"),
+            ("traduci in tedesco per favore", "it", "de"),
+            ("quiero aprender japonés", "es", "ja"),
+            ("auf Deutsch bitte", "de", "de"),
+            ("kannst du das auf Niederländisch sagen", "de", "nl"),
+        ]
+        for text, lang, expected in cases:
+            code, conf = extract_langcode(text, lang)
+            self.assertEqual(code, expected, text)
+            self.assertEqual(conf, 1.0, text)
+
+    def test_accented_name_embedded(self):
+        # accents inside a longer utterance must not lose the exact match
+        for text, lang, expected in [
+            ("eu falo alemão em casa", "pt", "de"),
+            ("ele fala francês", "pt", "fr"),
+            ("no hablo japonés", "es", "ja"),
+        ]:
+            code, conf = extract_langcode(text, lang)
+            self.assertEqual((code, conf), (expected, 1.0), text)
+
+    def test_longest_name_wins_over_substring(self):
+        # "American English" must not collapse to plain "English"
+        self.assertEqual(
+            extract_langcode("please use American English here", "en"),
+            ("en-us", 1.0))
+
+    def test_non_language_word_not_confidently_matched(self):
+        for text in ["hello there friend", "communication skills",
+                     "I want a hamburger please"]:
+            code, conf = extract_langcode(text, "en")
+            self.assertLess(conf, 0.6, text)
+
+    def test_non_string_text_does_not_raise(self):
+        for bad in [None, 123, 4.5, [], {}]:
+            self.assertEqual(extract_langcode(bad, "en"), ("", 0.0))
+
+    def test_empty_text_returns_no_match(self):
+        for text in ["", "   ", "\t\n"]:
+            self.assertEqual(extract_langcode(text, "en"), ("", 0.0))
+
+    def test_mixed_case_and_whitespace(self):
+        self.assertEqual(extract_langcode("  pOrTuGuEsE  ", "en")[0], "pt")
+
+    def test_unmatchable_script_returns_no_code(self):
+        # a name written in a script the wordlist has no entry for must not
+        # yield an arbitrary zero-confidence code
+        self.assertEqual(extract_langcode("日本語", "en"), ("", 0.0))
+
 
 class TestPronounceLang(unittest.TestCase):
     def test_samples(self):
@@ -231,6 +285,14 @@ class TestPronounceLang(unittest.TestCase):
     def test_unsupported_language_raises(self):
         with self.assertRaises(ValueError):
             pronounce_lang("en", "zz")
+
+    def test_non_string_code_returned_unchanged(self):
+        for bad in [None, 123, 4.5]:
+            self.assertEqual(pronounce_lang(bad, "en"), bad)
+
+    def test_region_variants_have_distinct_names(self):
+        self.assertEqual(pronounce_lang("en-us", "en"), "American English")
+        self.assertEqual(pronounce_lang("pt-br", "en"), "Brazilian Portuguese")
 
 
 class TestRoundTrip(unittest.TestCase):


### PR DESCRIPTION
Hardens `extract_langcode`/`pronounce_lang` against adversarial input and improves matching of language names inside natural sentences.

## Bugs fixed
- `extract_langcode(None, lang)` and non-string text (int/float/list/dict) raised `AttributeError` via `text.split()`. Now returns `("", 0.0)`.
- Empty/whitespace text returned an arbitrary first code (`aa`); a zero-confidence fuzzy result likewise returned an arbitrary code. Both now return `("", 0.0)`.
- A language name embedded in a longer utterance matched only via fuzzy scoring, which collapsed on accented names — `quiero aprender japonés` (es) missed `ja`, `eu falo alemão em casa` (pt) was fragile. Whole-word name runs are now matched exactly at confidence 1.0, with the longest name winning so `American English` stays `en-us`.
- `pronounce_lang(None, lang)` / non-string code raised `AttributeError`; now returned unchanged like any unknown code.

## Tests
Added natural-sentence and adversarial cases: embedded names across en/it/es/de/pt, accented-name-in-sentence, longest-name-wins, non-language-word low confidence, non-string/empty input, mixed case, unmatchable script, and distinct region-variant names. Full suite green (the pre-existing version-metadata env-artifact failure is unrelated).