### PR TITLE
feat: name the long tail of ISO-639 codes via CLDR fallback

### DIFF
--- a/ovos_lang_parser/__init__.py
+++ b/ovos_lang_parser/__init__.py
@@ -33,10 +33,17 @@ import re
 from functools import lru_cache
 from typing import Dict, List, Tuple
 
+import langcodes
 from ovos_spec_tools.language import closest_lang, lang_distance, standardize_lang
-from ovos_utils.parse import match_one, MatchStrategy
+from ovos_utils.parse import match_one, fuzzy_match, MatchStrategy
 
 RES_DIR = f"{os.path.dirname(__file__)}/res"
+
+# A ``langcodes`` name->code guess is only trusted when the resolved code's own
+# display name (in the query language, in English, or its autonym) matches the
+# text this closely. ``langcodes.find`` is greedy and will otherwise resolve
+# ordinary words ("banana" -> bcw, "music" -> mos) to obscure languages.
+_LANGCODES_NAME_FLOOR = 0.9
 
 # languages with a bundled wordlist
 LANGS = sorted(entry for entry in os.listdir(RES_DIR)
@@ -108,6 +115,81 @@ def _closest_wordlist(lang: str) -> str:
     return match
 
 
+def _langcodes_names(code: str, lang: str) -> List[str]:
+    """Names ``langcodes`` knows for ``code``: display name in ``lang``, in
+    English, and the autonym. Empty when the code is unknown to CLDR (the
+    "Unknown language [xxx]" sentinel is treated as no name)."""
+    try:
+        language = langcodes.Language.get(code)
+    except (langcodes.tag_parser.LanguageTagError, ValueError):
+        return []
+    names = []
+    for display in (lang, "en"):
+        try:
+            name = language.display_name(display)
+        except Exception:
+            continue
+        if name and not name.lower().startswith("unknown language"):
+            names.append(name)
+    try:
+        autonym = language.autonym()
+    except Exception:
+        autonym = ""
+    if autonym and not autonym.lower().startswith("unknown language"):
+        names.append(autonym)
+    # de-dup, preserve order
+    seen = []
+    for name in names:
+        if name not in seen:
+            seen.append(name)
+    return seen
+
+
+def _langcodes_name(lang_code: str, lang: str) -> str:
+    """CLDR display name for ``lang_code`` in ``lang``, or ``""``.
+
+    Mirrors the wordlist base-fallback contract: a regioned or private-use tag
+    with no name of its own resolves to its base-language name, so
+    ``pt-BR-x-caipira`` is named as Portuguese rather than crashing or leaking
+    the region into the name. The base subtag is tried first so a regioned tag
+    resolves to the plain base-language name (``mwl-PT`` -> "Mirandese", not
+    "Mirandese (Portugal)"), matching the wordlist base-fallback contract.
+    """
+    base = lang_code.split("-")[0]
+    for candidate in (base, lang_code) if base != lang_code else (lang_code,):
+        names = _langcodes_names(candidate, lang)
+        if names:
+            return names[0]
+    return ""
+
+
+def _langcodes_find(text: str, lang: str) -> Tuple[str, float]:
+    """Resolve a spoken language *name* to a code via CLDR, guarding against
+    ``langcodes.find`` greedily matching ordinary words.
+
+    Returns ``(code, confidence)`` only when the resolved code's own display
+    name matches ``text`` at or above :data:`_LANGCODES_NAME_FLOOR`; otherwise
+    ``("", 0.0)``.
+    """
+    try:
+        code = str(langcodes.find(text, language=lang))
+    except LookupError:
+        try:
+            code = str(langcodes.find(text))
+        except LookupError:
+            return "", 0.0
+    query = text.casefold()
+    names = _langcodes_names(code, lang)
+    if not names:
+        return "", 0.0
+    conf = max(fuzzy_match(query, name.casefold(),
+                           strategy=MatchStrategy.TOKEN_SORT_RATIO)
+               for name in names)
+    if conf < _LANGCODES_NAME_FLOOR:
+        return "", 0.0
+    return _normalize_code(code), conf
+
+
 def get_lang_data(lang: str) -> Dict[str, str]:
     """Map spoken language names in ``lang`` to language codes.
 
@@ -149,6 +231,13 @@ def extract_langcode(text: str, lang: str) -> Tuple[str, float]:
     if best is not None:
         return best[2], 1.0
     code, conf = match_one(query, langs, strategy=MatchStrategy.TOKEN_SET_RATIO)
+    # A strong wordlist match is authoritative and keeps its curated code.
+    # Only when the wordlist is unsure do we consult CLDR names (which cover
+    # languages no wordlist bundles), and never below the guarded floor.
+    if conf < _LANGCODES_NAME_FLOOR:
+        lc_code, lc_conf = _langcodes_find(query, lang)
+        if lc_conf and lc_conf > conf:
+            return lc_code, lc_conf
     # a zero-confidence "match" is no match at all; don't return an
     # arbitrary code for it
     if not conf:
@@ -178,4 +267,11 @@ def pronounce_lang(lang_code: str, lang: str) -> str:
     # "an-x-ansotano" -> "an". The "-x-" subtag carries no base name of its
     # own, so the primary subtag is the fallback lookup key.
     base_code = full_code.split("-")[0]
-    return names.get(full_code) or names.get(base_code) or lang_code
+    curated = names.get(full_code) or names.get(base_code)
+    if curated:
+        return curated
+    # No curated name: fall back to the CLDR display name in the requested
+    # language, which covers the long tail of ISO-639 codes no wordlist bundles
+    # (mwl -> "Mirandese", lij -> "Ligurian"). Only truly unknown or private-use
+    # codes fall through to the code returned unchanged.
+    return _langcodes_name(full_code, lang) or lang_code

--- a/test/test_lang_parser.py
+++ b/test/test_lang_parser.py
@@ -252,10 +252,33 @@ class TestExtractLangcode(unittest.TestCase):
     def test_mixed_case_and_whitespace(self):
         self.assertEqual(extract_langcode("  pOrTuGuEsE  ", "en")[0], "pt")
 
-    def test_unmatchable_script_returns_no_code(self):
-        # a name written in a script the wordlist has no entry for must not
-        # yield an arbitrary zero-confidence code
-        self.assertEqual(extract_langcode("日本語", "en"), ("", 0.0))
+    def test_unmatchable_text_returns_no_code(self):
+        # text that names no language at all must not yield an arbitrary
+        # zero-confidence code, not even from the CLDR name fallback
+        self.assertEqual(extract_langcode("12345", "en"), ("", 0.0))
+        self.assertEqual(extract_langcode("!!!", "en"), ("", 0.0))
+
+    def test_cldr_name_fallback_for_unbundled_language(self):
+        # a CLDR name for a language no wordlist bundles resolves via the
+        # guarded langcodes fallback, in English and localized
+        self.assertEqual(extract_langcode("Mirandese", "en"), ("mwl", 1.0))
+        self.assertEqual(extract_langcode("Ligurian", "en"), ("lij", 1.0))
+        self.assertEqual(extract_langcode("Extremaduran", "en"), ("ext", 1.0))
+        self.assertEqual(extract_langcode("mirandês", "pt"), ("mwl", 1.0))
+        # a CLDR autonym in its own script is recognized too
+        self.assertEqual(extract_langcode("日本語", "en"), ("ja", 1.0))
+
+    def test_cldr_fallback_rejects_non_language_words(self):
+        # langcodes.find is greedy ("banana" -> bcw, "music" -> mos); the
+        # guarded fallback must never surface those obscure codes
+        for word in ["banana", "music", "the", "water", "yellow"]:
+            code, _ = extract_langcode(word, "en")
+            self.assertNotIn(code, ("bcw", "mos", "thx"), word)
+
+    def test_curated_wordlist_wins_over_cldr(self):
+        # a strong curated match keeps its curated code, not a CLDR reading
+        self.assertEqual(extract_langcode("Portuguese", "en"), ("pt", 1.0))
+        self.assertEqual(extract_langcode("English", "en"), ("en", 1.0))
 
 
 class TestPronounceLang(unittest.TestCase):
@@ -278,6 +301,21 @@ class TestPronounceLang(unittest.TestCase):
 
     def test_unknown_code_returned_unchanged(self):
         self.assertEqual(pronounce_lang("xx", "en"), "xx")
+
+    def test_cldr_names_unbundled_codes(self):
+        # codes no wordlist bundles are named from CLDR, in English...
+        self.assertEqual(pronounce_lang("mwl", "en"), "Mirandese")
+        self.assertEqual(pronounce_lang("ast", "en"), "Asturian")
+        self.assertEqual(pronounce_lang("lij", "en"), "Ligurian")
+        self.assertEqual(pronounce_lang("ext", "en"), "Extremaduran")
+        self.assertEqual(pronounce_lang("akk", "en"), "Akkadian")
+        # ...and localized into the requested display language
+        self.assertEqual(pronounce_lang("mwl", "pt"), "mirandês")
+
+    def test_curated_wordlist_wins_over_cldr(self):
+        # a curated wordlist name is preserved even where CLDR differs
+        self.assertEqual(pronounce_lang("pt", "en"), "Portuguese")
+        self.assertEqual(pronounce_lang("en-us", "en"), "American English")
 
     def test_malformed_code_returned_unchanged(self):
         self.assertEqual(pronounce_lang("not a tag", "en"), "not a tag")
@@ -317,10 +355,14 @@ class TestRegionAndPrivateUseTags(unittest.TestCase):
         # base name resolved in a wordlist that bundles it
         self.assertEqual(pronounce_lang("an-x-ansotano", "an"), "Aragonés")
 
-    def test_private_use_tag_without_base_name_returned_unchanged(self):
-        # base language absent from the wordlist -> unchanged, never raises
-        # (English has no name for Aragonese "an")
-        self.assertEqual(pronounce_lang("an-x-ansotano", "en"), "an-x-ansotano")
+    def test_private_use_tag_base_named_via_cldr(self):
+        # the English wordlist bundles no name for Aragonese "an", but CLDR
+        # does -> the base-language name, with the region/-x- subtag dropped
+        self.assertEqual(pronounce_lang("an-x-ansotano", "en"), "Aragonese")
+        self.assertEqual(pronounce_lang("mwl-PT", "en"), "Mirandese")
+
+    def test_private_use_tag_without_any_name_returned_unchanged(self):
+        # base language unknown to both wordlist and CLDR -> unchanged, no crash
         self.assertEqual(pronounce_lang("zz-x-madeup", "en"), "zz-x-madeup")
 
     def test_standardize_preserves_region_and_private_use(self):


### PR DESCRIPTION
Names essentially all ISO-639 / BCP-47 languages by falling back to the CLDR data carried by langcodes when the curated wordlists have no entry, without hand-authoring wordlists.

## What changes

- pronounce_lang: after the existing most-specific-first wordlist lookup (full tag then base), fall back to langcodes display_name(code) in the requested display language. Curated wordlist entries still win. Truly unknown / private-use codes return the code unchanged, preserving the current contract. Regioned / -x- tags resolve to the plain base-language name (mwl-PT -> Mirandese, not "Mirandese (Portugal)").
- extract_langcode: as an additional fallback after the wordlist fuzzy match, resolve names via langcodes.find. Because langcodes.find is greedy (banana -> bcw, music -> mos), the guess is only trusted when the resolved code display name matches the text at or above a confidence floor, and it never overrides a strong wordlist match. The zero-confidence floor is preserved.

## Coverage

Against orthography2ipa unique base codes (567): nameable in English went from 149 to 562 (+413 newly named, e.g. mwl -> Mirandese, ast -> Asturian, lij -> Ligurian, ext -> Extremaduran, an -> Aragonese). Localized names work too (mwl -> mirandês in pt). Only a handful of retired / constructed / private-use codes remain unnamed.

## Tests

New tests cover CLDR naming of unbundled codes (English and localized), wordlist precedence, the guarded name-to-code fallback, adversarial rejection of non-language words, and region / private-use base fallback. Full suite green (excluding the pre-existing packaging env-artifact).