### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ovos-lang-parser
 
-Map spoken and written **language names** to standard **IETF/BCP-47 language codes** — and
-back — in many languages, offline, with a two-function API.
+Map spoken and written **language names** to standard **IETF/BCP-47 language codes**, and
+back, in many languages, offline, with a two-function API.
 
 ```
 "Brazilian Portuguese"  ->  "pt-br"
@@ -14,7 +14,7 @@ The library understands language names written in **21 languages** (see
 [Coverage](#coverage)). A user can say "French" in English, "français" in French, or
 "Französisch" in German, and each resolves to the code `fr`. This is the piece you need
 whenever a human names a language in free text and your code needs a canonical code to act
-on — routing to a translation/TTS/STT engine, tagging an entity, or normalizing a messy
+on: routing to a translation/TTS/STT engine, tagging an entity, or normalizing a messy
 label.
 
 It ships as part of OpenVoiceOS, but has **no OVOS runtime dependency** and is useful in any
@@ -29,8 +29,8 @@ uv add ovos-lang-parser
 ```
 
 Runtime dependencies are small: [`langcodes`](https://github.com/rspeer/langcodes) for tag
-normalization and `ovos-utils` for the fuzzy matcher. No models, no network calls — the
-wordlists are bundled.
+normalization and `ovos-utils` for the fuzzy matcher. There are no models and no network
+calls: the wordlists are bundled.
 
 ## 30-second quickstart
 
@@ -47,13 +47,13 @@ print(pronounce_lang("de", "pt"))   # -> Alemão
 ```
 
 That is the whole surface for most callers: `extract_langcode` reads a name out of text and
-returns `(code, confidence)`; `pronounce_lang` turns a code back into a human name.
+returns `(code, confidence)`. `pronounce_lang` turns a code back into a human name.
 
 ## The API in one screen
 
 | Function | Purpose | Returns |
 |----------|---------|---------|
-| `extract_langcode(text, lang)` | Find the language named in `text` (written in `lang`) | `(langcode, confidence)` — confidence `0.0`–`1.0`; an exact name match is `1.0` |
+| `extract_langcode(text, lang)` | Find the language named in `text` (written in `lang`) | `(langcode, confidence)`. Confidence is `0.0` to `1.0`, and an exact name match is `1.0` |
 | `pronounce_lang(langcode, lang)` | Human name of `langcode`, rendered in `lang` | `str` (falls back to the base tag, then to `langcode` unchanged) |
 | `get_lang_data(lang)` | The full `{name: code}` table for `lang` | `dict[str, str]` |
 | `LANGS` | Codes of the languages a name can be written in | `list[str]` |
@@ -66,10 +66,10 @@ behavior.
 ## Use it outside OVOS
 
 The same two functions cover a range of standalone jobs. Each example below is a runnable
-script under [`examples/`](examples/) — `pip install ovos-lang-parser` and run it, no OVOS
-stack required.
+script under [`examples/`](examples/): run `pip install ovos-lang-parser`, then run the script.
+No OVOS stack is required.
 
-### Entity extraction / NER — pull a language out of free text
+### Entity extraction / NER: pull a language out of free text
 
 You have a sentence and want to know which language it mentions.
 
@@ -88,9 +88,9 @@ Because matching is fuzzy, apply a confidence threshold to decide whether a lang
 really mentioned. Full script:
 [`examples/ner_language_mentions.py`](examples/ner_language_mentions.py).
 
-### Routing — pick a translation / TTS / STT engine by name
+### Routing: pick a translation / TTS / STT engine by name
 
-A user names a target language; you resolve it to a code and hand that to whatever engine
+A user names a target language. You resolve it to a code and hand that to whatever engine
 your pipeline drives.
 
 ```python
@@ -105,7 +105,7 @@ print(resolve_target("read it back to me in German"))   # -> de  (feed to your T
 
 Full script (with a mock engine table): [`examples/routing.py`](examples/routing.py).
 
-### Normalization — canonicalize messy names and autonyms to one code
+### Normalization: canonicalize messy names and autonyms to one code
 
 Aliases, autonyms, and localized spellings all collapse to a single canonical code, so you
 can deduplicate and standardize labels regardless of how they were written.
@@ -123,13 +123,13 @@ Full script: [`examples/normalization.py`](examples/normalization.py).
 
 ### In an OVOS skill vs. standalone
 
-The API is identical; only where you get `text` and `lang` differs.
+The API is identical. Only where you get `text` and `lang` differs.
 
 ```python
 # Standalone language-routing utility
 code, conf = extract_langcode(user_input, "en")
 
-# Inside an OVOS skill — the utterance and its language come from the session
+# Inside an OVOS skill, the utterance and its language come from the session
 class MySkill(OVOSSkill):
     def handle_translate(self, message):
         utterance = message.data["utterance"]
@@ -139,7 +139,7 @@ class MySkill(OVOSSkill):
 
 ## Coverage
 
-Names can be written in **21 languages**; each carries a table of a few hundred target
+Names can be written in **21 languages**. Each carries a table of a few hundred target
 languages keyed by ISO 639 code.
 
 | | | | |
@@ -151,23 +151,22 @@ languages keyed by ISO 639 code.
 | `nl` Dutch | `oc` Occitan | `pt` Portuguese | `ro` Romanian |
 | `sk` Slovak | | | |
 
-The live list is always `ovos_lang_parser.LANGS`. Adding a language is a matter of dropping
-in one JSON file — see [docs/coverage.md](docs/coverage.md) and
-[docs/extending.md](docs/extending.md).
+The live list is always `ovos_lang_parser.LANGS`. Adding a language means dropping in one
+JSON file. See [docs/coverage.md](docs/coverage.md) and [docs/extending.md](docs/extending.md).
 
 ## Documentation
 
-- [docs/api.md](docs/api.md) — full reference, confidence model, edge behavior
-- [docs/coverage.md](docs/coverage.md) — supported languages and the data model
-- [docs/extending.md](docs/extending.md) — add a language wordlist
-- [examples/](examples/) — runnable scripts for each use case
+- [docs/api.md](docs/api.md): full reference, confidence model, edge behavior
+- [docs/coverage.md](docs/coverage.md): supported languages and the data model
+- [docs/extending.md](docs/extending.md): add a language wordlist
+- [examples/](examples/): runnable scripts for each use case
 
 ## Related projects
 
-- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser) — numbers
-- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser) — dates and times
-- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) — colors
+- [ovos-number-parser](https://github.com/OpenVoiceOS/ovos-number-parser): numbers
+- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser): dates and times
+- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser): colors
 
 ## License
 
-Apache 2.0 — see [LICENSE](LICENSE).
+Apache 2.0. See [LICENSE](LICENSE).

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,8 +16,8 @@ Two ideas run through the whole API:
 - A **language code** is an IETF/BCP-47 tag such as `en`, `pt`, or `pt-br`. Codes are
   normalized to their modern lowercase form, so legacy tags collapse to the current one
   (`iw` → `he`, `jw` → `jv`, `mo` → `ro`).
-- The **`lang`** argument is always *the language the names are written in* — not the
-  language being named. To read a French sentence, pass `lang="fr"`; the code it resolves to
+- The **`lang`** argument is always *the language the names are written in*, not the
+  language being named. To read a French sentence, pass `lang="fr"`. The code it resolves to
   can be any language.
 
 ---
@@ -33,8 +33,8 @@ Find the language named in `text`, where `text` is written in `lang`.
 
 Returns `(langcode, confidence)`:
 
-- `langcode` — the best-matching BCP-47 code.
-- `confidence` — a float in `0.0`–`1.0`.
+- `langcode`: the best-matching BCP-47 code.
+- `confidence`: a float from `0.0` to `1.0`.
 
 Matching works in two stages:
 
@@ -42,7 +42,7 @@ Matching works in two stages:
    result is that code with confidence `1.0`.
 2. **Fuzzy match.** Otherwise a token-set-ratio matcher scores `text` against every known
    name and returns the best one. Because it is token-set based, a clean language name
-   surrounded by other words still scores `1.0` — the surrounding tokens do not count against
+   surrounded by other words still scores `1.0`. The surrounding tokens do not count against
    it. What *does* lower the score is punctuation stuck to the name (`Chinese?`), a
    misspelling, or text with no language name at all.
 
@@ -59,20 +59,20 @@ For best results on free text, strip surrounding punctuation before calling.
 ### Confidence and thresholds
 
 Because stage 2 always returns *some* best match, `extract_langcode` never signals "no
-language here" on its own — text with no language mention still returns a low-confidence
+language here" on its own. Text with no language mention still returns a low-confidence
 guess:
 
 ```python
-extract_langcode("the weather today", "en")           # e.g. ('rm', 0.45)  — noise
+extract_langcode("the weather today", "en")           # e.g. ('rm', 0.45)  (noise)
 ```
 
 Apply a threshold suited to your input. As a rule of thumb:
 
-- **`== 1.0`** — a clean, unambiguous name (safe to trust).
-- **`>= 0.7`** — a confident mention (good default for NER/routing).
-- **`< 0.5`** — treat as "no language mentioned".
+- **`== 1.0`**: a clean, unambiguous name (safe to trust).
+- **`>= 0.7`**: a confident mention (good default for NER/routing).
+- **`< 0.5`**: treat as "no language mentioned".
 
-Tune against your own data; noisy free text warrants a higher floor than short labels, and
+Tune against your own data. Noisy free text warrants a higher floor than short labels, and
 stripping punctuation first keeps genuine mentions above the threshold.
 
 ### Errors
@@ -131,8 +131,8 @@ the library knows. Raises `ValueError` if `lang` has no bundled wordlist.
 
 ## `LANGS -> list[str]`
 
-Sorted list of the language codes whose names the library can parse — i.e. valid values for
-the `lang` argument.
+Sorted list of the language codes whose names the library can parse. These are the valid
+values for the `lang` argument.
 
 ```python
 import ovos_lang_parser
@@ -141,7 +141,7 @@ ovos_lang_parser.LANGS
 #  'fy', 'gl', 'hr', 'it', 'kab', 'nl', 'oc', 'pt', 'ro', 'sk']
 ```
 
-`lang` does not have to be an exact member — it is matched to the closest available wordlist,
+`lang` does not have to be an exact member. It is matched to the closest available wordlist,
 so `en-us` and `en-gb` both use the `en` list. Only a `lang` with no close match raises.
 
 ---
@@ -150,7 +150,10 @@ so `en-us` and `en-gb` both use the `en` list. Only a `lang` with no close match
 
 - **Caching.** Wordlists are loaded once and memoized (`lru_cache`), so repeated calls are
   cheap. The first call for a given `lang` pays the JSON-load cost.
-- **Thread safety.** All functions are pure reads over immutable in-memory data; safe to call
-  concurrently.
+- **Thread safety.** All functions are pure reads over immutable in-memory data. They are safe
+  to call concurrently.
 - **No network, no models.** Everything resolves from bundled JSON under the package's `res/`
   directory. See [coverage.md](coverage.md) for the data model.
+
+---
+[Home](../README.md) · [Coverage →](coverage.md)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -2,7 +2,7 @@
 
 ## Languages you can parse names in
 
-`extract_langcode`, `pronounce_lang`, and `get_lang_data` all take a `lang` argument —
+`extract_langcode`, `pronounce_lang`, and `get_lang_data` all take a `lang` argument:
 the language the *names* are written in. The library ships wordlists for **21** of them:
 
 | Code | Language | Code | Language | Code | Language |
@@ -23,7 +23,7 @@ import ovos_lang_parser
 ovos_lang_parser.LANGS
 ```
 
-A `lang` value does not have to be an exact member — it is matched to the closest wordlist,
+A `lang` value does not have to be an exact member. It is matched to the closest wordlist,
 so regional variants like `en-us` or `pt-pt` resolve to `en` / `pt`. A `lang` too far from
 any bundled list raises `ValueError`.
 
@@ -32,7 +32,7 @@ any bundled list raises `ValueError`.
 Each wordlist maps a few hundred **target** languages (keyed by ISO 639 code) to their names
 in that language. So the `en` wordlist knows the English names of hundreds of languages, the
 `pt` wordlist their Portuguese names, and so on. The target set is far broader than the 21
-name languages above — you can resolve "Swahili", "Tibetan", or "Esperanto" even though the
+name languages above. You can resolve "Swahili", "Tibetan", or "Esperanto" even though the
 library cannot parse names *written in* those languages.
 
 Approximate distinct target codes per wordlist:
@@ -65,14 +65,14 @@ keyed by BCP-47 code:
 A value may also be a **template** using `(a|b)` alternation, which the loader expands into
 every spelling. For example `"Bislamá Bichlamar"` and templated forms like
 `"(Modern |)Greek"` become multiple accepted names, all mapping to the same code. The
-**first** name listed for a code is treated as canonical — it is what `pronounce_lang`
+**first** name listed for a code is treated as canonical. It is what `pronounce_lang`
 returns.
 
 At load time (`get_lang_data` / the internal loader):
 
 - codes are normalized to modern lowercase form (legacy `iw` → `he`, `jw` → `jv`,
-  `mo` → `ro`), so duplicate aliases merge onto one code;
-- templates are expanded to individual names;
+  `mo` → `ro`), so duplicate aliases merge onto one code
+- templates are expanded to individual names
 - results are memoized so a wordlist is parsed only once.
 
 Both full and base tags coexist: `pt` and `pt-br` are separate keys, which is what lets
@@ -80,3 +80,6 @@ Both full and base tags coexist: `pt` and `pt-br` are separate keys, which is wh
 …)` falls back to the `pt` name when a region-specific one is absent.
 
 To add a language, see [extending.md](extending.md).
+
+---
+[← API reference](api.md) · [Home](../README.md) · [Extending →](extending.md)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,7 +1,7 @@
 # Adding a language
 
 Teaching the parser to read language names written in a new language means adding one
-wordlist. No code changes are required — `LANGS` is discovered from the filesystem at import
+wordlist. No code changes are required. `LANGS` is discovered from the filesystem at import
 time.
 
 ## Steps
@@ -27,9 +27,9 @@ time.
    }
    ```
 
-   - The **first** name for a code is canonical — it is what `pronounce_lang` returns. List
+   - The **first** name for a code is canonical. It is what `pronounce_lang` returns. List
      the most natural spelling first.
-   - Provide both base and regional tags where they differ (`pt` and `pt-br`); a regional tag
+   - Provide both base and regional tags where they differ (`pt` and `pt-br`). A regional tag
      with no entry falls back to the base name automatically.
 
 3. **Add spelling variants with templates** when several forms should all resolve to one
@@ -42,7 +42,7 @@ time.
    Both "nygrekiska" and "grekiska" become accepted names for `el`. Alternations can appear
    anywhere in the string and nest.
 
-That is the whole contribution — drop the file in, and the new code appears in `LANGS`
+That is the whole contribution. Drop the file in, and the new code appears in `LANGS`
 automatically.
 
 ## Verifying your wordlist
@@ -66,8 +66,11 @@ print(len(get_lang_data("<lang>")), "names loaded")
 ## Conventions
 
 - Codes are normalized to modern lowercase form on load, so you may use legacy aliases
-  (`iw`, `jw`, `mo`) — they merge onto the current code (`he`, `jv`, `ro`). Prefer the modern
+  (`iw`, `jw`, `mo`). They merge onto the current code (`he`, `jv`, `ro`). Prefer the modern
   code when authoring.
-- Keep the file UTF-8 and valid JSON; the loader reads it directly.
-- Names are matched case-insensitively at runtime, so casing in the file is only cosmetic —
-  but keep it natural for `pronounce_lang` output.
+- Keep the file UTF-8 and valid JSON. The loader reads it directly.
+- Names are matched case-insensitively at runtime, so casing in the file is only cosmetic.
+  Keep it natural for `pronounce_lang` output.
+
+---
+[← Coverage](coverage.md) · [Home](../README.md)


### PR DESCRIPTION
Rewrites README.md and the three docs/ pages (api.md, coverage.md, extending.md) for clarity, removing semicolons and em dashes and tightening long sentences per ASD-STE100 style. Adds relative-link navigation footers to the docs/ pages so readers can move between them in one click. No facts, features, or claims were added or changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording, punctuation, and formatting throughout the README and documentation.
  * Clarified API argument semantics, return values, fuzzy matching, confidence thresholds, and advanced usage.
  * Expanded guidance for adding languages, including naming conventions and regional tags.
  * Added navigation links between coverage, API, home, and extending documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->